### PR TITLE
Issue #5: Add chat page layout with header

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,15 +1,41 @@
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-8">
-      <h1 className="text-4xl font-bold mb-4" style={{ color: 'var(--primary)' }}>
-        ELI5 Now!
-      </h1>
-      <p className="text-xl" style={{ color: 'var(--foreground-muted)' }}>
-        No Question Unanswered!
-      </p>
-      <p className="mt-8" style={{ color: 'var(--foreground-subtle)' }}>
-        Chat interface coming soon...
-      </p>
-    </main>
+    <div className="flex flex-col h-screen">
+      {/* Header */}
+      <header
+        className="flex items-center justify-center py-4 border-b"
+        style={{ borderColor: 'var(--surface-alt)', backgroundColor: 'var(--surface)' }}
+      >
+        <h1 className="text-2xl font-bold" style={{ color: 'var(--primary)' }}>
+          ELI5 Now!
+        </h1>
+      </header>
+
+      {/* Message area */}
+      <main
+        className="flex-1 overflow-y-auto p-4"
+        style={{ backgroundColor: 'var(--background)' }}
+      >
+        <p
+          className="text-center mt-8"
+          style={{ color: 'var(--foreground-subtle)' }}
+        >
+          Ask Eli anything!
+        </p>
+      </main>
+
+      {/* Input area placeholder */}
+      <footer
+        className="p-4 border-t"
+        style={{ borderColor: 'var(--surface-alt)', backgroundColor: 'var(--surface)' }}
+      >
+        <div
+          className="rounded-full px-4 py-3"
+          style={{ backgroundColor: 'var(--surface-alt)', color: 'var(--foreground-subtle)' }}
+        >
+          Type your question here...
+        </div>
+      </footer>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace placeholder with chat-style page layout
- Header with app title
- Message area (empty, ready for messages)
- Input area placeholder (non-functional)

## Structure
```
┌─────────────────────────┐
│      ELI5 Now!          │  ← Header
├─────────────────────────┤
│                         │
│   Ask Eli anything!     │  ← Message area
│                         │
├─────────────────────────┤
│ Type your question...   │  ← Input placeholder
└─────────────────────────┘
```

## How to Test
1. `cd frontend && npm run dev`
2. Open http://localhost:3000
3. **Expected**: 
   - Header with teal "ELI5 Now!" title at top
   - Empty message area with "Ask Eli anything!" prompt
   - Rounded input placeholder at bottom
   - Full-height layout (no scrolling on empty state)