### PR TITLE
Issue #6: Add MessageBubble component

### DIFF
--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -1,0 +1,25 @@
+interface MessageBubbleProps {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export function MessageBubble({ role, content }: MessageBubbleProps) {
+  const isUser = role === 'user';
+
+  return (
+    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} mb-4`}>
+      <div
+        className={`max-w-[80%] rounded-2xl px-4 py-3 ${
+          isUser ? 'rounded-br-sm' : 'rounded-bl-sm'
+        }`}
+        style={{
+          backgroundColor: isUser ? 'var(--bubble-user)' : 'var(--bubble-eli)',
+          color: 'var(--foreground)',
+          boxShadow: isUser ? 'none' : '0 1px 2px rgba(0,0,0,0.05)',
+        }}
+      >
+        {content}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Create reusable MessageBubble component for chat messages
- Different styling for user vs assistant (Eli) messages
- User messages: right-aligned, teal-tinted background
- Eli messages: left-aligned, white with subtle shadow

## Component API
```tsx
<MessageBubble role="user" content="Why is the sky blue?" />
<MessageBubble role="assistant" content="Great question! ..." />
```

## How to Test
Component not yet used in page. To verify:
1. `cd frontend && npm run dev` (should compile without errors)
2. Or add test usage in page.tsx temporarily