### PR TITLE
Issue #12: Wire up LLM to /ask endpoint

### DIFF
--- a/backend/app/routes/ask.py
+++ b/backend/app/routes/ask.py
@@ -2,6 +2,7 @@
 
 from fastapi import APIRouter
 from fastapi.responses import StreamingResponse
+from llama_index.core.llms import ChatMessage
 from pydantic import BaseModel
 
 from app.config import settings
@@ -74,8 +75,8 @@ async def generate_response(question: str, age: int, story_mode: bool):
     system_prompt = build_system_prompt(age, story_mode)
 
     messages = [
-        {"role": "system", "content": system_prompt},
-        {"role": "user", "content": question},
+        ChatMessage(role="system", content=system_prompt),
+        ChatMessage(role="user", content=question),
     ]
 
     response = await llm.achat(messages)


### PR DESCRIPTION
## Summary
- Replace mock responses with real LLM calls
- Add age-adaptive system prompts (4 age brackets)
- Add story mode support in prompts
- Use async LLM chat for non-blocking responses

## Age Brackets
| Age | Style |
|-----|-------|
| ≤4 | Very simple words, 2-3 sentences, playful |
| 5-7 | Simple vocab, cause-and-effect, 3-5 sentences |
| 8-10 | More complex, simple science, multi-step |
| 11+ | Nuanced, proper terminology, abstract concepts |

## How to Test
1. Copy `.env.example` to `.env` and add your OpenAI API key
2. Start backend: `cd backend && uv run uvicorn app.main:app --reload`
3. Start frontend: `cd frontend && npm run dev`
4. Ask a question - you should get a real LLM response!

## Note
Response arrives all at once (not token-by-token streaming yet). True token streaming would require changes to how LlamaIndex handles async streaming.